### PR TITLE
Normalize sitemap base URL

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next"
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://meowlabs.store"
+const fallbackBaseUrl = "https://meowlabs.store"
+const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? fallbackBaseUrl).replace(/\/$/, "")
 const siteUrl = new URL(baseUrl)
 
 export default function sitemap(): MetadataRoute.Sitemap {


### PR DESCRIPTION
## Summary
- normalize the sitemap base URL handling so it always falls back to https://meowlabs.store
- strip a trailing slash from any configured NEXT_PUBLIC_SITE_URL value before building sitemap entries

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d96cd3d60483268a404334029108be