### PR TITLE
Fix metadata exports for client redirect pages

### DIFF
--- a/app/jasa-pembuatan-website-semarang/page.tsx
+++ b/app/jasa-pembuatan-website-semarang/page.tsx
@@ -1,16 +1,14 @@
-"use client"
+import type { Metadata } from "next"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { Metadata } from "next"
+import RedirectMessage from "@/components/redirect-message"
 
 // Metadata for this specific page
-export const metadata = {
+export const metadata: Metadata = {
   title: "Jasa Pembuatan Website Profesional #1 di Semarang | Meow Labs",
   description: "Layanan jasa pembuatan website profesional terbaik dan termurah di Semarang. Desain modern, responsive, dan SEO friendly. Hubungi Meow Labs sekarang untuk konsultasi gratis!",
   keywords: [
     "jasa pembuatan website semarang",
-    "web developer semarang", 
+    "web developer semarang",
     "jasa website semarang",
     "jasa web semarang terbaik",
     "website murah semarang",
@@ -19,16 +17,5 @@ export const metadata = {
 }
 
 export default function JasaPembuatanWebsiteSemarang() {
-  const router = useRouter()
-
-  // Redirect to homepage with appropriate section focus
-  useEffect(() => {
-    router.push("/#services")
-  }, [router])
-
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <p>Redirecting to homepage...</p>
-    </div>
-  )
+  return <RedirectMessage href="/#services" message="Redirecting to homepage..." />
 }

--- a/app/jasa-web-design-semarang/page.tsx
+++ b/app/jasa-web-design-semarang/page.tsx
@@ -1,11 +1,9 @@
-"use client"
+import type { Metadata } from "next"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { Metadata } from "next"
+import RedirectMessage from "@/components/redirect-message"
 
 // Metadata for this specific page
-export const metadata = {
+export const metadata: Metadata = {
   title: "Jasa Web Design Semarang Terbaik | Meow Labs",
   description: "Jasa web design Semarang dengan desain UI/UX modern dan profesional. Tingkatkan kesan pertama bisnis Anda dengan website yang menarik dan responsif. Hubungi Meow Labs sekarang!",
   keywords: [
@@ -19,16 +17,5 @@ export const metadata = {
 }
 
 export default function JasaWebDesignSemarang() {
-  const router = useRouter()
-
-  // Redirect to homepage with appropriate section focus
-  useEffect(() => {
-    router.push("/#services")
-  }, [router])
-
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <p>Redirecting to homepage...</p>
-    </div>
-  )
+  return <RedirectMessage href="/#services" message="Redirecting to homepage..." />
 }

--- a/app/layanan/aplikasi-web/page.tsx
+++ b/app/layanan/aplikasi-web/page.tsx
@@ -1,11 +1,9 @@
-"use client"
+import type { Metadata } from "next"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { Metadata } from "next"
+import RedirectMessage from "@/components/redirect-message"
 
 // Metadata for this specific service page
-export const metadata = {
+export const metadata: Metadata = {
   title: "Jasa Pembuatan Aplikasi Web Custom di Semarang | Meow Labs",
   description: "Jasa pembuatan aplikasi web custom untuk kebutuhan bisnis di Semarang. Kembangkan sistem informasi, CRM, atau aplikasi khusus untuk meningkatkan efisiensi perusahaan Anda.",
   keywords: [
@@ -19,16 +17,5 @@ export const metadata = {
 }
 
 export default function AplikasiWebService() {
-  const router = useRouter()
-
-  // Redirect to services section
-  useEffect(() => {
-    router.push("/#services")
-  }, [router])
-
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <p>Redirecting to services section...</p>
-    </div>
-  )
+  return <RedirectMessage href="/#services" message="Redirecting to services section..." />
 }

--- a/app/layanan/company-profile/page.tsx
+++ b/app/layanan/company-profile/page.tsx
@@ -1,11 +1,9 @@
-"use client"
+import type { Metadata } from "next"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { Metadata } from "next"
+import RedirectMessage from "@/components/redirect-message"
 
 // Metadata for this specific service page
-export const metadata = {
+export const metadata: Metadata = {
   title: "Jasa Pembuatan Website Company Profile di Semarang | Meow Labs",
   description: "Jasa pembuatan website company profile profesional di Semarang. Tingkatkan citra perusahaan Anda dengan website yang elegan dan informatif. Mulai dari Rp 500rb!",
   keywords: [
@@ -19,16 +17,5 @@ export const metadata = {
 }
 
 export default function CompanyProfilePage() {
-  const router = useRouter()
-
-  // Redirect to services section
-  useEffect(() => {
-    router.push("/#services")
-  }, [router])
-
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <p>Redirecting to services section...</p>
-    </div>
-  )
+  return <RedirectMessage href="/#services" message="Redirecting to services section..." />
 }

--- a/app/layanan/landing-page/page.tsx
+++ b/app/layanan/landing-page/page.tsx
@@ -1,11 +1,9 @@
-"use client"
+import type { Metadata } from "next"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { Metadata } from "next"
+import RedirectMessage from "@/components/redirect-message"
 
 // Metadata for this specific service page
-export const metadata = {
+export const metadata: Metadata = {
   title: "Jasa Pembuatan Landing Page Profesional di Semarang | Meow Labs",
   description: "Jasa pembuatan landing page konversi tinggi di Semarang. Desain modern, responsif, dan fokus pada CTA untuk meningkatkan penjualan dan lead bisnis Anda.",
   keywords: [
@@ -19,16 +17,5 @@ export const metadata = {
 }
 
 export default function LandingPageService() {
-  const router = useRouter()
-
-  // Redirect to services section
-  useEffect(() => {
-    router.push("/#services")
-  }, [router])
-
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <p>Redirecting to services section...</p>
-    </div>
-  )
+  return <RedirectMessage href="/#services" message="Redirecting to services section..." />
 }

--- a/app/layanan/toko-online/page.tsx
+++ b/app/layanan/toko-online/page.tsx
@@ -1,11 +1,9 @@
-"use client"
+import type { Metadata } from "next"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { Metadata } from "next"
+import RedirectMessage from "@/components/redirect-message"
 
 // Metadata for this specific service page
-export const metadata = {
+export const metadata: Metadata = {
   title: "Jasa Pembuatan Toko Online di Semarang | Meow Labs",
   description: "Jasa pembuatan website toko online dan e-commerce di Semarang. Tingkatkan penjualan bisnis Anda dengan website e-commerce yang profesional dan user-friendly.",
   keywords: [
@@ -19,16 +17,5 @@ export const metadata = {
 }
 
 export default function TokoOnlinePage() {
-  const router = useRouter()
-
-  // Redirect to services section
-  useEffect(() => {
-    router.push("/#services")
-  }, [router])
-
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <p>Redirecting to services section...</p>
-    </div>
-  )
+  return <RedirectMessage href="/#services" message="Redirecting to services section..." />
 }

--- a/app/web-developer-semarang/page.tsx
+++ b/app/web-developer-semarang/page.tsx
@@ -1,11 +1,9 @@
-"use client"
+import type { Metadata } from "next"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { Metadata } from "next"
+import RedirectMessage from "@/components/redirect-message"
 
 // Metadata for this specific page
-export const metadata = {
+export const metadata: Metadata = {
   title: "Web Developer Profesional Semarang | Meow Labs",
   description: "Tim web developer profesional Semarang dengan portofolio terbaik. Ahli dalam pengembangan website modern, aplikasi web, dan solusi e-commerce. Konsultasi gratis!",
   keywords: [
@@ -19,16 +17,5 @@ export const metadata = {
 }
 
 export default function WebDeveloperSemarang() {
-  const router = useRouter()
-
-  // Redirect to homepage with appropriate section focus
-  useEffect(() => {
-    router.push("/#portfolio")
-  }, [router])
-
-  return (
-    <div className="min-h-screen flex items-center justify-center">
-      <p>Redirecting to homepage...</p>
-    </div>
-  )
+  return <RedirectMessage href="/#portfolio" message="Redirecting to homepage..." />
 }

--- a/components/redirect-message.tsx
+++ b/components/redirect-message.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+
+interface RedirectMessageProps {
+  href: string
+  message?: string
+}
+
+export default function RedirectMessage({ href, message }: RedirectMessageProps) {
+  const router = useRouter()
+
+  useEffect(() => {
+    router.push(href)
+  }, [href, router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <p>{message ?? "Redirecting..."}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- convert the redirect-only marketing pages into server components so their metadata exports compile
- add a shared client-side redirect helper that preserves the previous redirect behaviour

## Testing
- pnpm run build *(fails: NextFontError: Failed to fetch font `Poppins` and `JetBrains Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_68d9922bd5808326a86c391fd94c6df4