### PR TITLE
Redirect marketing CTAs to booking platform

### DIFF
--- a/components/contact-section.tsx
+++ b/components/contact-section.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Mail, Phone, MapPin, Send } from "lucide-react"
+import { openBookingPage } from "@/lib/booking"
 
 export function ContactSection() {
   const [formData, setFormData] = useState({
@@ -19,16 +20,18 @@ export function ContactSection() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    // Handle form submission via WhatsApp
-    const message = `Hallo admin, saya ingin konsultasi pembuatan website.%0A%0ANama: ${formData.name}%0AEmail: ${formData.email}%0APerusahaan: ${formData.organization}%0A%0APesan: ${formData.message}`
-    const whatsappUrl = `https://api.whatsapp.com/send?phone=62895386288683&text=${message}`
-    window.open(whatsappUrl, "_blank")
+    openBookingPage({
+      name: formData.name,
+      email: formData.email,
+      organization: formData.organization,
+      message: formData.message,
+    })
   }
 
-  const handleWhatsAppContact = () => {
-    const message = "Hallo admin saya ingin konsultasi pembuatan website..."
-    const whatsappUrl = `https://api.whatsapp.com/send?phone=62895386288683&text=${encodeURIComponent(message)}`
-    window.open(whatsappUrl, "_blank")
+  const handleBookingContact = () => {
+    openBookingPage({
+      message: "Saya ingin booking konsultasi cepat dengan tim Meow Labs",
+    })
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -129,7 +132,7 @@ export function ContactSection() {
                   className="w-full bg-primary text-primary-foreground hover:bg-primary/90 glow-animation"
                 >
                   <Send className="mr-2 h-4 w-4" />
-                  Kirim Pesan
+                  Lanjut ke Booking
                 </Button>
               </form>
             </CardContent>
@@ -193,14 +196,16 @@ export function ContactSection() {
 
             {/* CTA */}
             <div className="bg-gradient-to-r from-primary/5 to-secondary/5 rounded-xl p-6 text-center">
-              <h4 className="font-semibold text-foreground mb-2">Butuh Konsultasi Cepat?</h4>
-              <p className="text-sm text-muted-foreground mb-4">Chat langsung dengan tim kami via WhatsApp untuk konsultasi gratis!</p>
-              <Button 
+              <h4 className="font-semibold text-foreground mb-2">Siap Mulai Sekarang?</h4>
+              <p className="text-sm text-muted-foreground mb-4">
+                Booking jadwal konsultasi gratis dan pilih waktu yang paling cocok untuk Anda.
+              </p>
+              <Button
                 className="bg-secondary text-secondary-foreground hover:bg-secondary/90"
-                onClick={handleWhatsAppContact}
+                onClick={handleBookingContact}
               >
                 <Phone className="mr-2 h-4 w-4" />
-                WhatsApp Sekarang
+                Booking Konsultasi
               </Button>
             </div>
           </div>

--- a/components/discount-popup.tsx
+++ b/components/discount-popup.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { openBookingPage } from '@/lib/booking'
 
 export function DiscountPopup() {
   const [isOpen, setIsOpen] = useState(false)
@@ -16,12 +17,10 @@ export function DiscountPopup() {
     return () => clearTimeout(timer)
   }, [])
 
-  const handleWhatsAppContact = () => {
-    const phoneNumber = "62895386288683"
-    const message = "Halo! Saya ingin mendapatkan promo diskon 30% untuk 10 klien pertama!"
-    const encodedMessage = encodeURIComponent(message)
-    const whatsappUrl = `https://api.whatsapp.com/send?phone=${phoneNumber}&text=${encodedMessage}`
-    window.open(whatsappUrl, "_blank")
+  const handleBookingContact = () => {
+    openBookingPage({
+      message: "Saya ingin klaim promo diskon 30% untuk 10 klien pertama",
+    })
   }
 
   if (!isOpen) return null
@@ -65,8 +64,8 @@ export function DiscountPopup() {
         </div>
         
         <div className="space-y-3">
-          <Button 
-            onClick={handleWhatsAppContact}
+          <Button
+            onClick={handleBookingContact}
             className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
           >
             Klaim Diskon 30% Sekarang!

--- a/components/faq-section.tsx
+++ b/components/faq-section.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { ChevronDown, MessageCircle } from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
+import { openBookingPage } from "@/lib/booking"
 
 interface FAQItem {
   question: string
@@ -21,9 +22,10 @@ export function FAQSection() {
     )
   }
 
-  const handleWhatsAppContact = () => {
-    const message = encodeURIComponent("Halo Meow Labs! Saya punya pertanyaan tentang layanan pembuatan website.")
-    window.open(`https://wa.me/62895386288683?text=${message}`, '_blank')
+  const handleBookingContact = () => {
+    openBookingPage({
+      message: "Saya ingin booking sesi tanya jawab mengenai layanan Meow Labs",
+    })
   }
 
   const faqs: FAQItem[] = [
@@ -126,8 +128,8 @@ export function FAQSection() {
                 <p className="text-muted-foreground mb-6 text-pretty">
                   Tim kami siap membantu menjawab pertanyaan spesifik tentang kebutuhan website Anda
                 </p>
-                <Button onClick={handleWhatsAppContact} className="w-full sm:w-auto">
-                  Tanya via WhatsApp
+                <Button onClick={handleBookingContact} className="w-full sm:w-auto">
+                  Booking Sesi Tanya Jawab
                 </Button>
               </div>
             </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -2,18 +2,21 @@
 
 import Image from "next/image"
 import { MapPin, Phone, Mail, Clock, Star, ExternalLink, Instagram, Facebook, Linkedin } from "lucide-react"
+import { openBookingPage } from "@/lib/booking"
 
 export function Footer() {
   const currentYear = new Date().getFullYear()
 
-  const handleWhatsAppContact = () => {
-    const message = encodeURIComponent("Halo Meow Labs! Saya tertarik dengan layanan pembuatan website. Mohon info lebih lanjut.")
-    window.open(`https://wa.me/62895386288683?text=${message}`, '_blank')
+  const handleBookingContact = () => {
+    openBookingPage({
+      message: "Saya tertarik dengan layanan pembuatan website Meow Labs dan ingin booking konsultasi",
+    })
   }
 
   const handlePhoneClick = () => {
-    const message = encodeURIComponent("Halo Meow Labs! Saya tertarik dengan layanan pembuatan website dan ingin konsultasi.")
-    window.open(`https://wa.me/62895386288683?text=${message}`, '_blank')
+    openBookingPage({
+      message: "Saya ingin booking konsultasi pembuatan website dengan Meow Labs",
+    })
   }
 
   const techPartners = [
@@ -216,6 +219,14 @@ export function Footer() {
               </div>
               <span className="text-sm text-muted-foreground">4.9/5 dari 100+ klien</span>
             </div>
+
+            <button
+              onClick={handleBookingContact}
+              className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+            >
+              <Phone className="h-4 w-4" />
+              Booking Konsultasi
+            </button>
 
             {/* Social Media Links */}
             <div className="flex items-center gap-3">

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -3,14 +3,13 @@
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { ArrowRight, Mail } from "lucide-react"
+import { openBookingPage } from "@/lib/booking"
 
 export function HeroSection() {
-  function handleWhatsAppContact() {
-    const phoneNumber = "62895386288683" // Nomor WhatsApp admin
-    const message = "Hallo admin saya ingin konsultasi gratis untuk pembuatan website"
-    const encodedMessage = encodeURIComponent(message)
-    const whatsappUrl = `https://api.whatsapp.com/send?phone=${phoneNumber}&text=${encodedMessage}`
-    window.open(whatsappUrl, "_blank")
+  function handleBookingClick() {
+    openBookingPage({
+      message: "Saya ingin booking konsultasi pembuatan website dengan Meow Labs",
+    })
   }
 
   function handlePortfolioClick() {
@@ -54,12 +53,12 @@ export function HeroSection() {
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
-              <Button 
-                size="lg" 
+              <Button
+                size="lg"
                 className="bg-primary text-primary-foreground hover:bg-primary/90 glow-animation group"
-                onClick={handleWhatsAppContact}
+                onClick={handleBookingClick}
               >
-                Konsultasi Gratis
+                Booking Konsultasi
                 <ArrowRight className="ml-2 h-4 w-4 group-hover:translate-x-1 transition-transform" />
               </Button>
               <Button

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -67,13 +67,9 @@ export function Navigation() {
                 {item.label}
               </Link>
             ))}
-            <a
-              href="https://wa.me/62895386288683?text=Halo%20Meow%20Labs!%20Saya%20ingin%20konsultasi%20pembuatan%20website"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
+            <a href="https://booking.meowlabs.id/" rel="noopener noreferrer" target="_blank">
               <Button className="bg-primary text-primary-foreground hover:bg-primary/90 glow-animation">
-                Hubungi Kami
+                Booking Sekarang
               </Button>
             </a>
           </div>
@@ -113,13 +109,9 @@ export function Navigation() {
                 </Link>
               ))}
               <div className="px-3 py-2">
-                <a
-                  href="https://wa.me/62895386288683?text=Halo%20Meow%20Labs!%20Saya%20ingin%20konsultasi%20pembuatan%20website"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
+                <a href="https://booking.meowlabs.id/" rel="noopener noreferrer" target="_blank">
                   <Button className="w-full bg-primary text-primary-foreground hover:bg-primary/90">
-                    Hubungi Kami
+                    Booking Sekarang
                   </Button>
                 </a>
               </div>

--- a/components/pricing-section.tsx
+++ b/components/pricing-section.tsx
@@ -6,13 +6,11 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Check, MessageCircle, ExternalLink, Users, Code2, Brain } from "lucide-react"
 import { useCallback } from "react"
+import { openBookingPage } from "@/lib/booking"
 
 export function PricingSection() {
-  const handleWhatsAppContact = useCallback((message: string) => {
-    const phoneNumber = "62895386288683"
-    const encodedMessage = encodeURIComponent(message)
-    const whatsappUrl = `https://api.whatsapp.com/send?phone=${phoneNumber}&text=${encodedMessage}`
-    window.open(whatsappUrl, "_blank")
+  const handleBookingContact = useCallback((message: string) => {
+    openBookingPage({ message })
   }, [])
 
   const handlePortfolioClick = useCallback(() => {
@@ -463,12 +461,12 @@ export function PricingSection() {
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}
                   >
-                    <Button 
-                      onClick={() => handleWhatsAppContact(pkg.whatsappMessage)}
+                    <Button
+                      onClick={() => handleBookingContact(pkg.whatsappMessage)}
                       className="w-full mt-6 bg-primary hover:bg-primary/90 text-primary-foreground group"
                     >
                       <MessageCircle className="mr-2 h-4 w-4" />
-                      PILIH PAKET
+                      BOOKING PAKET
                     </Button>
                   </motion.div>
                 </CardContent>
@@ -492,14 +490,14 @@ export function PricingSection() {
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
               >
-                <Button 
-                  onClick={() => handleWhatsAppContact("Hallo admin saya ingin konsultasi gratis pembuatan website paket custom")}
-                  variant="outline" 
+                <Button
+                  onClick={() => handleBookingContact("Saya ingin booking konsultasi untuk paket website custom")}
+                  variant="outline"
                   size="lg"
                   className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
                 >
                   <MessageCircle className="mr-2 h-4 w-4" />
-                  Konsultasi Gratis
+                  Booking Paket Custom
                 </Button>
               </motion.div>
               
@@ -647,12 +645,12 @@ export function PricingSection() {
                       whileHover={{ scale: 1.02 }}
                       whileTap={{ scale: 0.98 }}
                     >
-                      <Button 
+                      <Button
                         className="w-full mt-6 bg-primary hover:bg-primary/90 text-primary-foreground group"
-                        onClick={() => handleWhatsAppContact(pkg.whatsappMessage)}
+                        onClick={() => handleBookingContact(pkg.whatsappMessage)}
                       >
                         <MessageCircle className="mr-2 h-4 w-4" />
-                        PILIH PAKET
+                        BOOKING PAKET
                       </Button>
                     </motion.div>
                   </CardContent>
@@ -774,12 +772,12 @@ export function PricingSection() {
                       whileHover={{ scale: 1.02 }}
                       whileTap={{ scale: 0.98 }}
                     >
-                      <Button 
+                      <Button
                         className="w-full mt-6 bg-primary hover:bg-primary/90 text-primary-foreground group"
-                        onClick={() => handleWhatsAppContact(pkg.whatsappMessage)}
+                        onClick={() => handleBookingContact(pkg.whatsappMessage)}
                       >
                         <MessageCircle className="mr-2 h-4 w-4" />
-                        PILIH PAKET
+                        BOOKING PAKET
                       </Button>
                     </motion.div>
                   </CardContent>
@@ -901,12 +899,12 @@ export function PricingSection() {
                       whileHover={{ scale: 1.02 }}
                       whileTap={{ scale: 0.98 }}
                     >
-                      <Button 
+                      <Button
                         className="w-full mt-6 bg-primary hover:bg-primary/90 text-primary-foreground group"
-                        onClick={() => handleWhatsAppContact(pkg.whatsappMessage)}
+                        onClick={() => handleBookingContact(pkg.whatsappMessage)}
                       >
                         <MessageCircle className="mr-2 h-4 w-4" />
-                        PILIH PAKET
+                        BOOKING PAKET
                       </Button>
                     </motion.div>
                   </CardContent>
@@ -1008,12 +1006,12 @@ export function PricingSection() {
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}
                   >
-                    <Button 
+                    <Button
                       className="w-full mt-6 bg-primary hover:bg-primary/90 text-primary-foreground"
-                      onClick={() => handleWhatsAppContact("Hallo admin saya ingin berlangganan paket maintenance basic untuk website saya")}
+                      onClick={() => handleBookingContact("Saya ingin booking paket maintenance basic untuk website saya")}
                     >
                       <MessageCircle className="mr-2 h-4 w-4" />
-                      PILIH BASIC
+                      BOOKING BASIC
                     </Button>
                   </motion.div>
                 </CardContent>
@@ -1089,12 +1087,12 @@ export function PricingSection() {
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}
                   >
-                    <Button 
+                    <Button
                       className="w-full mt-6 bg-secondary hover:bg-secondary/90 text-secondary-foreground"
-                      onClick={() => handleWhatsAppContact("Hallo admin saya ingin berlangganan paket maintenance pro untuk website saya")}
+                      onClick={() => handleBookingContact("Saya ingin booking paket maintenance pro untuk website saya")}
                     >
                       <MessageCircle className="mr-2 h-4 w-4" />
-                      PILIH PRO
+                      BOOKING PRO
                     </Button>
                   </motion.div>
                 </CardContent>
@@ -1111,12 +1109,12 @@ export function PricingSection() {
           >
             <p className="text-sm text-muted-foreground">
               💡 <span className="font-medium">Tips:</span> Paket maintenance dapat disesuaikan dengan kebutuhan website Anda. 
-              <Button 
-                variant="link" 
+              <Button
+                variant="link"
                 className="text-primary p-0 h-auto font-medium underline"
-                onClick={() => handleWhatsAppContact("Hallo admin saya ingin konsultasi paket maintenance custom untuk website saya")}
+                onClick={() => handleBookingContact("Saya ingin booking konsultasi untuk paket maintenance custom")}
               >
-                Konsultasi gratis untuk paket custom
+                Booking konsultasi untuk paket custom
               </Button>
             </p>
           </motion.div>

--- a/components/process-section.tsx
+++ b/components/process-section.tsx
@@ -2,21 +2,23 @@
 
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { 
-  MessageSquare, 
-  PenTool, 
-  Code2, 
-  Rocket, 
+import {
+  MessageSquare,
+  PenTool,
+  Code2,
+  Rocket,
   CheckCircle,
   Clock,
   Users,
   Headphones
 } from "lucide-react"
+import { openBookingPage } from "@/lib/booking"
 
 export function ProcessSection() {
-  const handleWhatsAppContact = () => {
-    const message = encodeURIComponent("Halo Meow Labs! Saya ingin memulai project website. Mohon info prosesnya.")
-    window.open(`https://wa.me/62895386288683?text=${message}`, '_blank')
+  const handleBookingContact = () => {
+    openBookingPage({
+      message: "Saya ingin booking konsultasi untuk membahas proses pembuatan website",
+    })
   }
 
   const processes = [
@@ -173,8 +175,8 @@ export function ProcessSection() {
               Konsultasi gratis untuk membahas kebutuhan website Anda. 
               Tim kami siap membantu mewujudkan website impian bisnis Anda!
             </p>
-            <Button onClick={handleWhatsAppContact} size="lg" className="text-lg px-8">
-              Mulai Konsultasi Gratis
+            <Button onClick={handleBookingContact} size="lg" className="text-lg px-8">
+              Booking Konsultasi
             </Button>
           </div>
         </div>

--- a/components/services-section.tsx
+++ b/components/services-section.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Globe, Cpu, Smartphone, Database, Shield, Zap, X, CheckCircle, LucideIcon } from "lucide-react"
+import { openBookingPage } from "@/lib/booking"
 
 // Define interfaces for type safety
 interface ServiceFeature {
@@ -33,12 +34,10 @@ export function ServicesSection() {
     setIsModalOpen(false)
   }
 
-  const handleWhatsAppContact = (serviceName: string) => {
-    const phoneNumber = "62895386288683" // Nomor WhatsApp admin
-    const message = `Halo admin saya ingin konsultasi gratis tentang pembuatan website ${serviceName}`
-    const encodedMessage = encodeURIComponent(message)
-    const whatsappUrl = `https://api.whatsapp.com/send?phone=${phoneNumber}&text=${encodedMessage}`
-    window.open(whatsappUrl, "_blank")
+  const handleBookingContact = (serviceName: string) => {
+    openBookingPage({
+      message: `Saya ingin booking konsultasi untuk layanan ${serviceName} dari Meow Labs`,
+    })
   }
   const services: ServiceFeature[] = [
     {
@@ -263,11 +262,11 @@ export function ServicesSection() {
                     </Button>
                     <Button
                       size="sm"
-                      variant="default" 
+                      variant="default"
                       className={`flex-1 bg-${service.color} text-${service.color === "primary" ? "primary-foreground" : "secondary-foreground"} hover:bg-${service.color}/90`}
-                      onClick={() => handleWhatsAppContact(service.title)}
+                      onClick={() => handleBookingContact(service.title)}
                     >
-                      Hubungi Kami
+                      Booking Konsultasi
                     </Button>
                   </div>
                 </CardContent>
@@ -284,12 +283,12 @@ export function ServicesSection() {
               Setiap bisnis memiliki kebutuhan yang unik. Mari diskusikan bagaimana kami dapat membantu mewujudkan visi
               teknologi Anda dengan solusi yang tepat sasaran.
             </p>
-            <Button 
-              size="lg" 
+            <Button
+              size="lg"
               className="bg-primary text-primary-foreground hover:bg-primary/90 glow-animation"
-              onClick={() => handleWhatsAppContact("Custom Solution")}
+              onClick={() => handleBookingContact("Custom Solution")}
             >
-              Konsultasi Gratis
+              Booking Konsultasi
             </Button>
           </div>
         </div>
@@ -362,15 +361,15 @@ export function ServicesSection() {
                 </div>
 
                 <div className="flex flex-col sm:flex-row gap-4 pt-4">
-                  <Button 
-                    size="lg" 
+                  <Button
+                    size="lg"
                     className={`w-full bg-${selectedService.color} text-${selectedService.color === "primary" ? "primary-foreground" : "secondary-foreground"} hover:bg-${selectedService.color}/90`}
                     onClick={() => {
-                      handleWhatsAppContact(selectedService.title)
+                      handleBookingContact(selectedService.title)
                       handleCloseModal()
                     }}
                   >
-                    Konsultasi via WhatsApp
+                    Booking Konsultasi
                   </Button>
                   <Button 
                     variant="outline" 

--- a/components/student-packages-section.tsx
+++ b/components/student-packages-section.tsx
@@ -6,13 +6,11 @@ import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Check, ArrowRight } from 'lucide-react'
 import { useCallback } from 'react'
+import { openBookingPage } from '@/lib/booking'
 
 export function StudentPackagesSection() {
-  const handleWhatsAppContact = useCallback((message: string) => {
-    const phoneNumber = "62895386288683" // Nomor WhatsApp admin
-    const encodedMessage = encodeURIComponent(message)
-    const whatsappUrl = `https://api.whatsapp.com/send?phone=${phoneNumber}&text=${encodedMessage}`
-    window.open(whatsappUrl, "_blank")
+  const handleBookingContact = useCallback((message: string) => {
+    openBookingPage({ message })
   }, [])
 
   const packages = [
@@ -158,9 +156,9 @@ export function StudentPackagesSection() {
 
                 <Button
                   className="w-full bg-primary text-white hover:bg-primary/90"
-                  onClick={() => handleWhatsAppContact(pkg.whatsappMessage)}
+                  onClick={() => handleBookingContact(pkg.whatsappMessage)}
                 >
-                  Konsultasi Gratis
+                  Booking Konsultasi
                   <ArrowRight className="ml-1 h-4 w-4" />
                 </Button>
               </div>
@@ -172,10 +170,10 @@ export function StudentPackagesSection() {
           <p className="text-muted-foreground">
             Butuh paket custom untuk tugas akademik lainnya? Hubungi kami untuk diskusi lebih lanjut.
           </p>
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             className="mt-4"
-            onClick={() => handleWhatsAppContact("Hallo admin, saya ingin konsultasi untuk kebutuhan project akademik custom")}
+            onClick={() => handleBookingContact("Saya ingin booking konsultasi untuk kebutuhan project akademik custom")}
           >
             Diskusi Kebutuhan Custom
           </Button>

--- a/lib/booking.ts
+++ b/lib/booking.ts
@@ -1,0 +1,39 @@
+export const BOOKING_URL = "https://booking.meowlabs.id/"
+
+export type BookingParams = {
+  name?: string
+  email?: string
+  organization?: string
+  message?: string
+}
+
+export function buildBookingUrl(params?: BookingParams) {
+  const url = new URL(BOOKING_URL)
+
+  if (params) {
+    const searchParams = new URLSearchParams()
+
+    Object.entries(params).forEach(([key, value]) => {
+      if (value) {
+        searchParams.set(key, value)
+      }
+    })
+
+    const queryString = searchParams.toString()
+    if (queryString) {
+      url.search = queryString
+    }
+  }
+
+  return url.toString()
+}
+
+export function openBookingPage(params?: BookingParams) {
+  const bookingUrl = buildBookingUrl(params)
+
+  if (typeof window !== "undefined") {
+    window.open(bookingUrl, "_blank", "noopener")
+  }
+
+  return bookingUrl
+}


### PR DESCRIPTION
## Summary
- add a reusable booking helper for constructing URLs with optional lead metadata
- update navigation, hero, pricing, services, and other CTA buttons to open the booking experience with refreshed copy
- adjust the contact flow to forward form details to the booking page instead of WhatsApp

## Testing
- pnpm lint *(fails: prompts to configure ESLint)*
- pnpm build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4a4ff4548326874bfe5b9b0f8a13